### PR TITLE
feat(providers): add QwenCloud compatible provider

### DIFF
--- a/frontend/app/app.js
+++ b/frontend/app/app.js
@@ -790,7 +790,7 @@ const App = (() => {
     if (p === 'fireworks') return 'Fireworks API key';
     if (p === 'perplexity') return 'pplx-...  -  perplexity.ai/settings/api';
     if (p === 'cerebras') return 'Cerebras API key';
-    if (p === 'qwencloud') return 'sk-...  -  dashscope.console.aliyun.com/apiKey';
+    if (p === 'qwencloud') return 'sk-...  -  modelstudio.console.alibabacloud.com (China: dashscope.console.aliyun.com)';
     if (p === 'custom') return 'optional API key for this endpoint';
     return 'sk-or-...  -  openrouter.ai/keys';
   }
@@ -810,7 +810,7 @@ const App = (() => {
       fireworks: 'https://fireworks.ai/account/api-keys',
       perplexity: 'https://www.perplexity.ai/settings/api',
       cerebras: 'https://cloud.cerebras.ai',
-      qwencloud: 'https://dashscope.console.aliyun.com/apiKey',
+      qwencloud: 'https://modelstudio.console.alibabacloud.com/?tab=playground#/api-key',
       // not a key page: managed credits are obtained by LINKING a station in the STORE
       starnet: 'https://account.starnetos.com',
       openrouter: 'https://openrouter.ai/keys'

--- a/frontend/app/app.js
+++ b/frontend/app/app.js
@@ -733,6 +733,7 @@ const App = (() => {
       fireworks: 'FIREWORKS',
       perplexity: 'PERPLEXITY',
       cerebras: 'CEREBRAS',
+      qwencloud: 'QWENCLOUD',
       starnet: 'STARNET MANAGED',
       ollama: 'OLLAMA',
       custom: 'CUSTOM'
@@ -757,6 +758,7 @@ const App = (() => {
     if (p === 'fireworks' || p === 'fireworks-ai') return 'fireworks';
     if (p === 'perplexity' || p === 'pplx' || p === 'sonar') return 'perplexity';
     if (p === 'cerebras') return 'cerebras';
+    if (p === 'qwencloud' || p === 'qwen' || p === 'dashscope' || p === 'qwen-cloud' || p === 'alibaba') return 'qwencloud';
     // managed credits — its bearer is the linked device token, never a key the user pastes
     if (p === 'starnet' || p === 'starnet-cloud' || p === 'managed') return 'starnet';
     if (p === 'ollama' || p === 'ollama-local') return 'ollama';
@@ -788,6 +790,7 @@ const App = (() => {
     if (p === 'fireworks') return 'Fireworks API key';
     if (p === 'perplexity') return 'pplx-...  -  perplexity.ai/settings/api';
     if (p === 'cerebras') return 'Cerebras API key';
+    if (p === 'qwencloud') return 'sk-...  -  dashscope.console.aliyun.com/apiKey';
     if (p === 'custom') return 'optional API key for this endpoint';
     return 'sk-or-...  -  openrouter.ai/keys';
   }
@@ -807,6 +810,7 @@ const App = (() => {
       fireworks: 'https://fireworks.ai/account/api-keys',
       perplexity: 'https://www.perplexity.ai/settings/api',
       cerebras: 'https://cloud.cerebras.ai',
+      qwencloud: 'https://dashscope.console.aliyun.com/apiKey',
       // not a key page: managed credits are obtained by LINKING a station in the STORE
       starnet: 'https://account.starnetos.com',
       openrouter: 'https://openrouter.ai/keys'
@@ -817,8 +821,11 @@ const App = (() => {
   // stranding the user on an empty required field. Reuses the curated FALLBACK_MODELS lineup (first = best pick).
   function defaultModelFor(provider) {
     const p = normalizeProviderId(provider);
-    const list = FALLBACK_MODELS[p] || FALLBACK_MODELS.openrouter;
-    return (list && list[0]) || 'anthropic/claude-sonnet-4.6';
+    if (p === 'custom') return '';
+    const list = FALLBACK_MODELS[p];
+    if (list && list.length) return list[0];
+    if (p === 'openrouter') return (FALLBACK_MODELS.openrouter[0]) || 'anthropic/claude-sonnet-4.6';
+    return '';
   }
   function applyQuickModel(sel) {
     if (!agent || !sel) return;
@@ -1467,6 +1474,8 @@ const App = (() => {
     fireworks: ['accounts/fireworks/models/deepseek-v3p1', 'accounts/fireworks/models/kimi-k2p5', 'accounts/fireworks/models/llama-v3p3-70b-instruct'],
     perplexity: ['sonar-pro', 'sonar', 'sonar-reasoning-pro'],
     cerebras: ['llama-4-scout-17b-16e-instruct', 'llama3.1-8b', 'qwen-3-coder-480b'],
+    qwencloud: ['qwen-plus', 'qwen-max', 'qwen-turbo'],
+    custom: [],
     ollama: ['llama3.1', 'qwen2.5-coder', 'mistral'],
     openrouter: ['gpt-5.5', 'anthropic/claude-sonnet-4.6', 'anthropic/claude-opus-4.8', 'openai/gpt-5', 'google/gemini-2.5-pro']
   });
@@ -1497,12 +1506,14 @@ const App = (() => {
       // catalog unreachable (no network to openrouter.ai, or fetch blocked): seed the curated slugs MARKED
       // offline so the popover never reads as a verified live catalog. The screen stays usable — you can always
       // just type the slug you use.
-      const FALLBACK = FALLBACK_MODELS[p] || FALLBACK_MODELS.openrouter;
+      const FALLBACK = FALLBACK_MODELS[p] ?? (p === 'custom' ? [] : FALLBACK_MODELS.openrouter);
       genesisModels = FALLBACK.map(id => ({ id, name: id, fallback: true }));
       genesisOffline = true;
       countEl.textContent = '(catalog offline — type or pick a slug)';
-      if (!inp.value) inp.value = defId || FALLBACK[0];   // default-fill even offline so WAKE works; the Commander can overtype
-      inp.placeholder = 'type a model slug — e.g. ' + (defId || 'gpt-5.5');
+      if (!inp.value) inp.value = defId || FALLBACK[0] || '';
+      inp.placeholder = p === 'custom'
+        ? 'type a model slug for your endpoint'
+        : 'type a model slug — e.g. ' + (defId || FALLBACK[0] || 'gpt-5.5');
     }
     if (el('model-pop') && !el('model-pop').hidden) renderModelPop();   // live-refresh an open popover after a provider switch
     updateHint();
@@ -1564,6 +1575,10 @@ const App = (() => {
     cerebras: [
       { label: 'Llama 4 Scout', id: 'llama-4-scout-17b-16e-instruct', tag: 'fast' },
       { label: 'Llama 3.1 8B', id: 'llama3.1-8b', tag: '' }
+    ],
+    qwencloud: [
+      { label: 'Qwen Plus', id: 'qwen-plus', tag: 'balanced' },
+      { label: 'Qwen Max', id: 'qwen-max', tag: 'deepest' }
     ]
   });
   /* ---------- PHOSPHOR tint picker (the console-wide theme, surfaced at commission) ----------

--- a/frontend/app/harness.js
+++ b/frontend/app/harness.js
@@ -307,6 +307,7 @@ const Harness = (() => {
     if (p === 'fireworks' || p === 'fireworks-ai') return 'fireworks';
     if (p === 'perplexity' || p === 'pplx' || p === 'sonar') return 'perplexity';
     if (p === 'cerebras') return 'cerebras';
+    if (p === 'qwencloud' || p === 'qwen' || p === 'dashscope' || p === 'qwen-cloud' || p === 'alibaba') return 'qwencloud';
     // managed credits — bearer is the linked device token (mirrors app.js + registry.js aliases)
     if (p === 'starnet' || p === 'starnet-cloud' || p === 'managed') return 'starnet';
     if (p === 'ollama' || p === 'ollama-local') return 'ollama';
@@ -561,7 +562,7 @@ const Harness = (() => {
       name: (m && (m.name || m.id)) || '',
       pricing: (m && m.pricing) || null,
       context_length: (m && +m.context_length) || 0,
-      supportsTools: (m && typeof m.supportsTools === 'boolean') ? m.supportsTools : (params.length ? params.indexOf('tools') >= 0 : true),
+      supportsTools: (m && typeof m.supportsTools === 'boolean') ? m.supportsTools : (params.indexOf('tools') >= 0 ? true : null),
       supportsReasoning: !!(m && m.supportsReasoning),
       supported_parameters: params,
       reasoningEfforts: Array.isArray(m && m.reasoningEfforts) ? m.reasoningEfforts.slice() : []

--- a/frontend/app/modeldock.js
+++ b/frontend/app/modeldock.js
@@ -20,7 +20,8 @@ const ModelDock = (() => {
     together: ['meta-llama/Llama-3.3-70B-Instruct-Turbo', 'Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8', 'deepseek-ai/DeepSeek-V3'],
     fireworks: ['accounts/fireworks/models/deepseek-v3p1', 'accounts/fireworks/models/kimi-k2p5', 'accounts/fireworks/models/llama-v3p3-70b-instruct'],
     perplexity: ['sonar-pro', 'sonar', 'sonar-reasoning-pro'],
-    cerebras: ['llama-4-scout-17b-16e-instruct', 'llama3.1-8b', 'qwen-3-coder-480b']
+    cerebras: ['llama-4-scout-17b-16e-instruct', 'llama3.1-8b', 'qwen-3-coder-480b'],
+    qwencloud: ['qwen-plus', 'qwen-max', 'qwen-turbo']
   };
   // OpenRouter fallback seed — real slugs only (shown labelled "(catalog offline)" when the live fetch fails).
   const OPENROUTER_FALLBACK = [
@@ -57,7 +58,7 @@ const ModelDock = (() => {
     qwen: 'QWEN',
     cohere: 'COHERE'
   };
-  const PROVIDER_RANK = { starnet: -1, codex: 0, grok: 1, kimi: 2, openrouter: 3, openai: 4, anthropic: 5, gemini: 6, xai: 7, groq: 8, mistral: 9, deepseek: 10, together: 11, fireworks: 12, perplexity: 13, cerebras: 14, ollama: 15, custom: 16 };
+  const PROVIDER_RANK = { starnet: -1, codex: 0, grok: 1, kimi: 2, openrouter: 3, openai: 4, anthropic: 5, gemini: 6, xai: 7, groq: 8, mistral: 9, deepseek: 10, together: 11, fireworks: 12, perplexity: 13, cerebras: 14, qwencloud: 15, ollama: 16, custom: 17 };
 
   let opts = {};
   let wired = false;
@@ -72,7 +73,7 @@ const ModelDock = (() => {
   }
   function providerLabel(p) {
     p = normalizeProvider(p);
-    const map = { starnet: 'STARNET', codex: 'GPT / CODEX', grok: 'GROK OAUTH', kimi: 'KIMI OAUTH', openrouter: 'OPENROUTER', openai: 'OPENAI API', anthropic: 'ANTHROPIC', gemini: 'GEMINI', xai: 'XAI', groq: 'GROQ', mistral: 'MISTRAL', deepseek: 'DEEPSEEK', together: 'TOGETHER', fireworks: 'FIREWORKS', perplexity: 'PERPLEXITY', cerebras: 'CEREBRAS', ollama: 'OLLAMA', custom: 'CUSTOM' };
+    const map = { starnet: 'STARNET', codex: 'GPT / CODEX', grok: 'GROK OAUTH', kimi: 'KIMI OAUTH', openrouter: 'OPENROUTER', openai: 'OPENAI API', anthropic: 'ANTHROPIC', gemini: 'GEMINI', xai: 'XAI', groq: 'GROQ', mistral: 'MISTRAL', deepseek: 'DEEPSEEK', together: 'TOGETHER', fireworks: 'FIREWORKS', perplexity: 'PERPLEXITY', cerebras: 'CEREBRAS', qwencloud: 'QWENCLOUD', ollama: 'OLLAMA', custom: 'CUSTOM' };
     return map[p] || String(p || 'openrouter').toUpperCase();
   }
   function normalizeProvider(p) {
@@ -92,6 +93,7 @@ const ModelDock = (() => {
     if (p === 'fireworks' || p === 'fireworks-ai') return 'fireworks';
     if (p === 'perplexity' || p === 'pplx' || p === 'sonar') return 'perplexity';
     if (p === 'cerebras') return 'cerebras';
+    if (p === 'qwencloud' || p === 'qwen' || p === 'dashscope' || p === 'qwen-cloud' || p === 'alibaba') return 'qwencloud';
     // managed credits — bearer is the linked device token (mirrors app.js + registry.js aliases)
     if (p === 'starnet' || p === 'starnet-cloud' || p === 'managed') return 'starnet';
     if (p === 'ollama' || p === 'ollama-local') return 'ollama';
@@ -402,7 +404,7 @@ const ModelDock = (() => {
     renderList();
     // 'starnet' first: a linked station's own credits are the most direct way to run, and its catalog is
     // the whole managed lineup. providerEnabled() keeps it out of the list when no credits are configured.
-    const ids = ['starnet', 'codex', 'grok', 'kimi', 'openrouter', 'openai', 'anthropic', 'gemini', 'xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras', 'ollama', 'custom'];
+    const ids = ['starnet', 'codex', 'grok', 'kimi', 'openrouter', 'openai', 'anthropic', 'gemini', 'xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras', 'qwencloud', 'ollama', 'custom'];
     const active = provider();
     if (ids.indexOf(active) < 0) ids.unshift(active);
     const parts = await Promise.all(ids.map(p => fetchProviderModels(p, force)));
@@ -750,7 +752,7 @@ const ModelDock = (() => {
   // `ensure: { id, provider }` guarantees a specific model (e.g. an agent's own pin) is present even if the
   // provider is unconfigured, so the picker can always show + preselect it. Returns [{ id, name, provider, … }].
   async function computeCatalog(force, ensure) {
-    const ids = ['codex', 'grok', 'kimi', 'openrouter', 'openai', 'anthropic', 'gemini', 'xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras', 'ollama', 'custom'];
+    const ids = ['codex', 'grok', 'kimi', 'openrouter', 'openai', 'anthropic', 'gemini', 'xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras', 'qwencloud', 'ollama', 'custom'];
     const active = provider();
     if (ids.indexOf(active) < 0) ids.unshift(active);
     const parts = await Promise.all(ids.map(p => fetchProviderModels(p, force).catch(() => [])));

--- a/frontend/app/stationui.js
+++ b/frontend/app/stationui.js
@@ -3846,7 +3846,7 @@ const StationUI = typeof document === 'undefined' ? {} : (() => {
     { id: 'fireworks',     name: 'FIREWORKS',         endpoint: 'api.fireworks.ai/inference/v1', blurb: 'Fireworks API', live: true },
     { id: 'perplexity',    name: 'PERPLEXITY',        endpoint: 'api.perplexity.ai',          blurb: 'Sonar API', live: true },
     { id: 'cerebras',      name: 'CEREBRAS',          endpoint: 'api.cerebras.ai/v1',         blurb: 'Cerebras API', live: true },
-    { id: 'qwencloud',     name: 'QWENCLOUD',         endpoint: 'dashscope.aliyuncs.com/compatible-mode/v1', blurb: 'Alibaba DashScope API', live: true },
+    { id: 'qwencloud',     name: 'QWENCLOUD',         endpoint: 'dashscope-intl.aliyuncs.com/compatible-mode/v1', blurb: 'Qwen Cloud / Model Studio API', live: true },
     { id: 'ollama',        name: 'OLLAMA',            endpoint: '127.0.0.1:11434/v1',         blurb: 'local models', live: true },
     { id: 'custom',        name: 'CUSTOM',            endpoint: 'any /v1 base URL',           blurb: 'bring your endpoint', live: true }
   ];

--- a/frontend/app/stationui.js
+++ b/frontend/app/stationui.js
@@ -3846,6 +3846,7 @@ const StationUI = typeof document === 'undefined' ? {} : (() => {
     { id: 'fireworks',     name: 'FIREWORKS',         endpoint: 'api.fireworks.ai/inference/v1', blurb: 'Fireworks API', live: true },
     { id: 'perplexity',    name: 'PERPLEXITY',        endpoint: 'api.perplexity.ai',          blurb: 'Sonar API', live: true },
     { id: 'cerebras',      name: 'CEREBRAS',          endpoint: 'api.cerebras.ai/v1',         blurb: 'Cerebras API', live: true },
+    { id: 'qwencloud',     name: 'QWENCLOUD',         endpoint: 'dashscope.aliyuncs.com/compatible-mode/v1', blurb: 'Alibaba DashScope API', live: true },
     { id: 'ollama',        name: 'OLLAMA',            endpoint: '127.0.0.1:11434/v1',         blurb: 'local models', live: true },
     { id: 'custom',        name: 'CUSTOM',            endpoint: 'any /v1 base URL',           blurb: 'bring your endpoint', live: true }
   ];

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -193,6 +193,7 @@
                 <button class="prov tail" data-prov="fireworks" aria-pressed="false">FIREWORKS</button>
                 <button class="prov tail" data-prov="perplexity" aria-pressed="false">PERPLEXITY</button>
                 <button class="prov tail" data-prov="cerebras" aria-pressed="false">CEREBRAS</button>
+                <button class="prov tail" data-prov="qwencloud" aria-pressed="false">QWENCLOUD</button>
                 <button class="prov tail" data-prov="custom" aria-pressed="false">CUSTOM</button>
                 <!-- label is COMPUTED by setProviderRowExpanded() from the live .prov.tail count — never hardcoded -->
                 <button type="button" id="prov-more" class="prov-more" aria-expanded="false">＋ MORE</button>

--- a/sidecar/index.js
+++ b/sidecar/index.js
@@ -17822,6 +17822,11 @@ function handleCodexStatus(req, res) {
 // GET /api/auth/codex/models — the ACCOUNT's real Codex model list (live-discovered with a fresh token), so
 // the connect screen offers exactly the slugs the backend will accept. Falls back to the provider's curated
 // list (and reports the error) when not connected / discovery fails, so the dropdown is never empty.
+function catalogSupportsTools(m) {
+  if (typeof m.supportsTools === 'boolean') return m.supportsTools;
+  const params = Array.isArray(m && m.supported_parameters) ? m.supported_parameters : [];
+  return params.indexOf('tools') >= 0 ? true : null;
+}
 function publicModel(m) {
   return {
     id: m.id,
@@ -17829,8 +17834,11 @@ function publicModel(m) {
     context_length: m.context_length || 0,
     max_completion_tokens: m.max_completion_tokens || null,
     pricing: m.pricing || null,
-    supportsTools: m.supportsTools !== false,
-    supportsReasoning: !!m.supportsReasoning,
+    // null = honestly unknown (custom endpoints + most OpenAI-compatible catalogs omit capability
+    // metadata). Never coerce unknown -> true (false-refuses task runs) or unknown -> false
+    // (false-refuses capable models on stale catalogs).
+    supportsTools: catalogSupportsTools(m),
+    supportsReasoning: m.supportsReasoning === true,
     supported_parameters: Array.isArray(m.supported_parameters) ? m.supported_parameters : [],
     reasoningEfforts: Array.isArray(m.reasoningEfforts) ? m.reasoningEfforts : []
   };

--- a/sidecar/providers/openai-compatible.js
+++ b/sidecar/providers/openai-compatible.js
@@ -55,7 +55,8 @@
       max_completion_tokens: Number(m.max_completion_tokens || m.max_output_tokens || 0) || null,
       pricing: m.pricing || null,
       supported_parameters: params,
-      supportsTools: typeof m.supportsTools === 'boolean' ? m.supportsTools : (params.length ? params.indexOf('tools') >= 0 : null),
+      // supported_parameters without 'tools' is unknown (null), not false — many catalogs omit the flag.
+      supportsTools: typeof m.supportsTools === 'boolean' ? m.supportsTools : (params.indexOf('tools') >= 0 ? true : null),
       supportsReasoning: typeof m.supportsReasoning === 'boolean' ? m.supportsReasoning : null,
       reasoningEfforts: Array.isArray(m.reasoningEfforts) ? m.reasoningEfforts.slice() : []
     };

--- a/sidecar/providers/prices.js
+++ b/sidecar/providers/prices.js
@@ -272,7 +272,7 @@
   ];
 
   // Alibaba Model Studio / DashScope list rates (USD per Mtok, standard tier), approximate 2026-08.
-  // Verified against help.aliyun.com model pricing snapshots; family fallbacks stay conservative.
+  // Sourced from public pricing docs; family fallbacks stay conservative until tests pin each id.
   const QWEN = [
     [/^qwen3\.5-plus/i,               { in: 0.40, out: 1.20 }],
     [/^qwen3\.5-flash/i,              { in: 0.10, out: 0.40 }],

--- a/sidecar/providers/prices.js
+++ b/sidecar/providers/prices.js
@@ -271,7 +271,27 @@
     [/./,                            { in: 1.20, out: 1.20 }]     // any other serverless id: the top size tier
   ];
 
-  const TABLES = { anthropic: ANTHROPIC, gemini: GEMINI, openai: OPENAI, xai: XAI, groq: GROQ, mistral: MISTRAL, deepseek: DEEPSEEK, together: TOGETHER, fireworks: FIREWORKS };
+  // Alibaba Model Studio / DashScope list rates (USD per Mtok, standard tier), approximate 2026-08.
+  // Verified against help.aliyun.com model pricing snapshots; family fallbacks stay conservative.
+  const QWEN = [
+    [/^qwen3\.5-plus/i,               { in: 0.40, out: 1.20 }],
+    [/^qwen3\.5-flash/i,              { in: 0.10, out: 0.40 }],
+    [/^qwen3-max/i,                   { in: 1.60, out: 6.40 }],
+    [/^qwen-max/i,                    { in: 1.60, out: 6.40 }],
+    [/^qwen-plus/i,                   { in: 0.40, out: 1.20 }],
+    [/^qwen-turbo/i,                  { in: 0.05, out: 0.20 }],
+    [/^qwen-long/i,                   { in: 0.40, out: 1.20 }],
+    [/^qwen2\.5-72b/i,                { in: 0.40, out: 1.20 }],
+    [/^qwen2\.5-32b/i,                { in: 0.20, out: 0.60 }],
+    [/^qwen2\.5-14b/i,                { in: 0.10, out: 0.30 }],
+    [/^qwen2\.5-7b/i,                 { in: 0.05, out: 0.15 }],
+    [/^qwen2\.5-coder/i,              { in: 0.20, out: 0.60 }],
+    [/^qwen2\.5/i,                    { in: 0.20, out: 0.60 }],
+    [/^qwen3/i,                       { in: 0.40, out: 1.20 }],
+    [/qwen/i,                         { in: 0.40, out: 1.20 }]
+  ];
+
+  const TABLES = { anthropic: ANTHROPIC, gemini: GEMINI, openai: OPENAI, xai: XAI, groq: GROQ, mistral: MISTRAL, deepseek: DEEPSEEK, together: TOGETHER, fireworks: FIREWORKS, qwen: QWEN };
 
   /* CACHE MULTIPLIERS, per family — what a cached prompt token bills relative to a fresh one. This exists
      because anthropic.js now actually ASKS for prompt caching: until then every cached_tokens figure was

--- a/sidecar/providers/registry.js
+++ b/sidecar/providers/registry.js
@@ -481,8 +481,8 @@
       aliases: ['qwen', 'dashscope', 'qwen-cloud', 'alibaba'],
       name: 'Qwen Cloud',
       label: 'QWENCLOUD',
-      endpoint: 'dashscope.aliyuncs.com/compatible-mode/v1',
-      blurb: 'Alibaba Model Studio (DashScope) OpenAI-compatible API',
+      endpoint: 'dashscope-intl.aliyuncs.com/compatible-mode/v1',
+      blurb: 'Qwen Cloud / Alibaba Model Studio OpenAI-compatible API',
       live: true,
       adapter: 'openai-compatible',
       apiMode: 'chat_completions',
@@ -490,8 +490,9 @@
       keyRequired: true,
       keyEnv: ['DASHSCOPE_API_KEY', 'QWENCLOUD_API_KEY', 'QWEN_API_KEY'],
       modelsRequireAuth: true,
-      // Documented compatible-mode endpoint; override via DASHSCOPE_BASE_URL for intl/regional hosts.
-      baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+      // QwenCloud intl compatible-mode endpoint (default); override via DASHSCOPE_BASE_URL /
+      // QWENCLOUD_BASE_URL / QWEN_BASE_URL for China Model Studio or other regional hosts.
+      baseUrl: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
       baseUrlEnv: ['DASHSCOPE_BASE_URL', 'QWENCLOUD_BASE_URL', 'QWEN_BASE_URL'],
       modelsPath: '/models',
       defaultReasoningEffort: 'medium',

--- a/sidecar/providers/registry.js
+++ b/sidecar/providers/registry.js
@@ -476,6 +476,34 @@
       order: 44
     },
     {
+      id: 'qwencloud',
+      priceFamily: 'qwen',   // prices.js table — DashScope /models may omit token pricing
+      aliases: ['qwen', 'dashscope', 'qwen-cloud', 'alibaba'],
+      name: 'Qwen Cloud',
+      label: 'QWENCLOUD',
+      endpoint: 'dashscope.aliyuncs.com/compatible-mode/v1',
+      blurb: 'Alibaba Model Studio (DashScope) OpenAI-compatible API',
+      live: true,
+      adapter: 'openai-compatible',
+      apiMode: 'chat_completions',
+      authType: 'api_key',
+      keyRequired: true,
+      keyEnv: ['DASHSCOPE_API_KEY', 'QWENCLOUD_API_KEY', 'QWEN_API_KEY'],
+      modelsRequireAuth: true,
+      // Documented compatible-mode endpoint; override via DASHSCOPE_BASE_URL for intl/regional hosts.
+      baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+      baseUrlEnv: ['DASHSCOPE_BASE_URL', 'QWENCLOUD_BASE_URL', 'QWEN_BASE_URL'],
+      modelsPath: '/models',
+      defaultReasoningEffort: 'medium',
+      unmetered: false,
+      credentialPool: true,
+      supportsTools: true,   // DashScope chat completions support function calling; catalog may omit the flag
+      supportsReasoning: null,
+      // DashScope uses enable_thinking on select models, not OpenAI's reasoning_effort wire param.
+      wireReasoningEffort: false,
+      order: 45
+    },
+    {
       id: 'ollama',
       aliases: ['ollama-local'],
       name: 'Ollama',

--- a/src-tauri/src/credentials.rs
+++ b/src-tauri/src/credentials.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 pub(crate) const KEYCHAIN_SERVICE: &str = "ai.skynet.harness";
 pub(crate) const KEYCHAIN_ACCOUNT: &str = "openrouter";
-pub(crate) const KEYCHAIN_PROVIDERS: [&str; 13] = [
+pub(crate) const KEYCHAIN_PROVIDERS: [&str; 14] = [
     "openrouter",
     "openai",
     "anthropic",
@@ -22,6 +22,7 @@ pub(crate) const KEYCHAIN_PROVIDERS: [&str; 13] = [
     "fireworks",
     "perplexity",
     "cerebras",
+    "qwencloud",
     "custom",
 ];
 
@@ -32,7 +33,7 @@ pub(crate) const SIDECAR_CHANNEL_TOKEN_ENVS: [(&str, &str); 2] = [
     ("discord", "SKYNET_DISCORD_TOKEN"),
 ];
 
-pub(crate) const SIDECAR_PROVIDER_KEY_ENVS: [(&str, &str); 12] = [
+pub(crate) const SIDECAR_PROVIDER_KEY_ENVS: [(&str, &str); 13] = [
     ("openai", "SKYNET_OPENAI_API_KEY"),
     ("anthropic", "SKYNET_ANTHROPIC_API_KEY"),
     ("gemini", "SKYNET_GEMINI_API_KEY"),
@@ -44,6 +45,7 @@ pub(crate) const SIDECAR_PROVIDER_KEY_ENVS: [(&str, &str); 12] = [
     ("fireworks", "SKYNET_FIREWORKS_API_KEY"),
     ("perplexity", "SKYNET_PERPLEXITY_API_KEY"),
     ("cerebras", "SKYNET_CEREBRAS_API_KEY"),
+    ("qwencloud", "SKYNET_QWENCLOUD_API_KEY"),
     ("custom", "SKYNET_CUSTOM_OPENAI_KEY"),
 ];
 
@@ -63,6 +65,7 @@ pub(crate) fn normalize_provider(provider: &str) -> &'static str {
         "fireworks" | "fireworks-ai" => "fireworks",
         "perplexity" | "pplx" | "sonar" => "perplexity",
         "cerebras" => "cerebras",
+        "qwencloud" | "qwen" | "dashscope" | "qwen-cloud" | "alibaba" => "qwencloud",
         "ollama" | "ollama-local" => "ollama",
         "custom" | "openai-compatible" | "local" | "vllm" | "lmstudio" => "custom",
         _ => "openrouter",
@@ -414,6 +417,7 @@ mod tests {
             ("pplx", "perplexity"),
             ("ollama-local", "ollama"),
             ("lmstudio", "custom"),
+            ("dashscope", "qwencloud"),
             ("unknown-provider", "openrouter"),
         ];
         for (input, expected) in cases {

--- a/test/ctx-model-catalog.test.js
+++ b/test/ctx-model-catalog.test.js
@@ -96,7 +96,7 @@ const OPUS_VIA_OR = {
 
 // every provider ModelDock warms; only anthropic is configured here
 const ALL_PROVIDERS = ['openrouter', 'openai', 'anthropic', 'gemini', 'codex', 'grok', 'kimi', 'xai',
-  'groq', 'mistral', 'deepseek', 'together', 'cerebras', 'fireworks', 'perplexity', 'ollama', 'custom'];
+  'groq', 'mistral', 'deepseek', 'together', 'cerebras', 'qwencloud', 'fireworks', 'perplexity', 'ollama', 'custom'];
 
 (async () => {
   /* 1. the ACTIVE provider's catalog warms and is readable */

--- a/test/fast.list
+++ b/test/fast.list
@@ -86,6 +86,7 @@ test/provider.prices.test.js
 test/prices.all-providers.test.js
 test/provider.timeouts.test.js
 test/provider.registry.test.js
+test/provider.qwencloud.test.js
 test/ratelimits.test.js
 test/provider.codex-auth.test.js
 test/purge-leaked-codex-tokens.test.js

--- a/test/prices.all-providers.test.js
+++ b/test/prices.all-providers.test.js
@@ -38,6 +38,7 @@ const UNPRICED_BY_DESIGN = {
 const REPRESENTATIVE = {
   openai: 'gpt-5.4', xai: 'grok-4.6', groq: 'openai/gpt-oss-120b', mistral: 'mistral-medium-latest',
   deepseek: 'deepseek-chat', together: 'deepseek-ai/DeepSeek-V4-Pro-0813', fireworks: 'accounts/fireworks/models/kimi-k3',
+  qwencloud: 'qwen-plus',
   anthropic: 'claude-opus-5', gemini: 'gemini-3.5-flash', openrouter: 'openai/gpt-5.4'
 };
 
@@ -71,7 +72,8 @@ function burnProvider(tokensPerTurn, priceOf) {
       ['mistral',   'mistral-medium-latest',                    { in: 1.50, out: 7.50 },  'mistral-colossal-latest'],
       ['deepseek',  'deepseek-v4-pro',                          { in: 0.435, out: 0.87 }, 'deepseek-v9'],
       ['together',  'deepseek-ai/DeepSeek-V4-Pro-0813',         { in: 1.32, out: 3.96 },  'Qwen/Qwen9-Giant'],
-      ['fireworks', 'accounts/fireworks/models/kimi-k3',        { in: 3.00, out: 15.00 }, 'accounts/fireworks/models/never-heard-of-it']
+      ['fireworks', 'accounts/fireworks/models/kimi-k3',        { in: 3.00, out: 15.00 }, 'accounts/fireworks/models/never-heard-of-it'],
+      ['qwen',      'qwen-plus',                                { in: 0.40, out: 1.20 },  'qwen-never-heard-of-it']
     ];
     for (const [fam, known, rate, unknown] of cases) {
       const k = prices.priceOf(fam, known);
@@ -271,7 +273,7 @@ function burnProvider(tokensPerTurn, priceOf) {
       else if (p.adapter === 'openrouter') priced = { in: 1, out: 1, via: 'wire' };
       A.ok(priced && priced.in >= 0 && priced.out >= 0, p.id + ' (' + p.adapter + '): default model ' + id + ' is priced -> the spend cap can fire');
     }
-    A.ok(checked >= 9, 'the ratchet covered the metered profiles (' + checked + ')');
+    A.ok(checked >= 10, 'the ratchet covered the metered profiles (' + checked + ')');
     // and the allowlist cannot silently grow to cover a profile that is actually priceable now
     A.eq(Object.keys(UNPRICED_BY_DESIGN).filter(k => !profiles.some(p => p.id === k)).length, 0, 'every allowlist entry names a real profile');
   }

--- a/test/provider-connections-ui.test.js
+++ b/test/provider-connections-ui.test.js
@@ -16,7 +16,7 @@ const tauri = ['main.rs', 'credentials.rs']
 
 let n = 0;
 const ok = (cond, msg) => { assert.ok(cond, msg); n++; };
-const hostedProviders = ['xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras'];
+const hostedProviders = ['xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras', 'qwencloud'];
 
 ok(!/Harness\.setKey\(\s*['"]{2}\s*\)/.test(app), 'Codex wake does not clear the OpenRouter BYOK slot');
 ok(/provider\s*!==\s*'codex'[\s\S]{0,80}reqBody\.key\s*=\s*key/.test(harness), 'browser BYOK key is sent only for key-backed provider runs');
@@ -71,5 +71,8 @@ ok(/const\s+health\s*=\s*providerHealth\[k\.provider\]/.test(station) &&
    !/const\s+runnable\s*=\s*k\.provider\s*===\s*active\s*&&\s*!!k\.model/.test(station),
   'the API-key rows also reserve ACTIVE for probe-proven runnability instead of selection alone');
 ok(!/connected\s*\?\s*connLabel[\s\S]{0,160}p\.id\s*===\s*'ollama'\s*\?\s*'[^']*LOCAL'/.test(station), 'Ollama does not fall through the generic credential status copy');
+
+ok(/function defaultModelFor\(provider\)[\s\S]*if \(p === 'custom'\) return ''/.test(app), 'custom defaultModelFor does not fall back to OpenRouter slugs');
+ok(/custom:\s*\[\]/.test(app), 'custom FALLBACK_MODELS stays empty so offline UX does not inject OpenRouter ids');
 
 console.log('provider-connections-ui.test.js OK -', n, 'assertions');

--- a/test/provider.openai-compatible.test.js
+++ b/test/provider.openai-compatible.test.js
@@ -181,6 +181,23 @@ module.exports = (async () => {
     A.eq(toolPosts.every(c => JSON.parse(c.init.body).tools !== undefined), true, 'no retry ever removed the tools payload');
   }
 
+  // supported_parameters without 'tools' stays unknown (null), not false — only an explicit 'tools' entry is positive proof
+  {
+    const fetchImpl = async () => new Response(JSON.stringify({
+      data: [
+        { id: 'with-tools', supported_parameters: ['tools', 'temperature'] },
+        { id: 'without-tools', supported_parameters: ['temperature', 'top_p'] },
+        { id: 'bare' }
+      ]
+    }), { status: 200 });
+    const p = makeOpenAICompatibleProvider({ fetch: fetchImpl, baseUrl: 'http://local/v1' });
+    const models = await p.listModels();
+    const byId = id => models.find(m => m.id === id);
+    A.eq(byId('with-tools').supportsTools, true, 'supported_parameters containing tools => true');
+    A.eq(byId('without-tools').supportsTools, null, 'supported_parameters without tools => unknown, not false');
+    A.eq(byId('bare').supportsTools, null, 'no supported_parameters => unknown');
+  }
+
   // profile-level tool capability is the fallback when the catalog is silent; catalog booleans win
   {
     const fetchImpl = async (url, init) => {

--- a/test/provider.qwencloud.test.js
+++ b/test/provider.qwencloud.test.js
@@ -1,0 +1,32 @@
+/* node test/provider.qwencloud.test.js — QwenCloud/DashScope first-class provider behavior. */
+'use strict';
+const A = require('./_assert.js');
+const factory = require('../sidecar/providers/factory.js');
+const prices = require('../sidecar/providers/prices.js');
+
+module.exports = (async () => {
+  const profile = factory.getProviderProfile('qwencloud');
+  A.ok(profile, 'qwencloud profile exists');
+  A.eq(profile.baseUrl, 'https://dashscope.aliyuncs.com/compatible-mode/v1', 'default DashScope compatible-mode base URL');
+  A.eq(profile.priceFamily, 'qwen', 'qwen price family is wired');
+  A.eq(prices.priceOf('qwen', 'qwen-plus').in, 0.40, 'qwen-plus has list pricing for spend caps');
+
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    if (init && init.method === 'POST') {
+      return new Response('data: [DONE]\n\n', { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+    }
+    return new Response(JSON.stringify({ data: [{ id: 'qwen-plus', context_length: 131072 }] }), { status: 200 });
+  };
+  const p = factory.selectProvider({ provider: 'qwencloud', fetch: fetchImpl, key: 'dashscope-test-key' });
+  const models = await p.listModels();
+  A.eq(models[0].id, 'qwen-plus', 'lists models from DashScope /models');
+  A.eq(p.supportsTools('qwen-plus'), true, 'profile asserts tool support when catalog is silent');
+  A.eq(p.supportsTools('brand-new-qwen-model'), true, 'unknown qwencloud ids inherit profile tool support');
+  for await (const _ of p.stream({ model: 'qwen-plus', messages: [], reasoningEffort: 'medium' })) { /* drain */ }
+  const post = calls.find(c => c.init && c.init.method === 'POST');
+  A.eq(JSON.parse(post.init.body).reasoning_effort, undefined, 'QwenCloud does not send OpenAI reasoning_effort');
+
+  A.report('provider.qwencloud.test');
+})();

--- a/test/provider.qwencloud.test.js
+++ b/test/provider.qwencloud.test.js
@@ -7,7 +7,10 @@ const prices = require('../sidecar/providers/prices.js');
 module.exports = (async () => {
   const profile = factory.getProviderProfile('qwencloud');
   A.ok(profile, 'qwencloud profile exists');
-  A.eq(profile.baseUrl, 'https://dashscope.aliyuncs.com/compatible-mode/v1', 'default DashScope compatible-mode base URL');
+  A.eq(profile.baseUrl, 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1', 'default QwenCloud intl compatible-mode base URL');
+  A.ok((profile.baseUrlEnv || []).indexOf('DASHSCOPE_BASE_URL') >= 0, 'DASHSCOPE_BASE_URL override is wired');
+  A.ok((profile.baseUrlEnv || []).indexOf('QWENCLOUD_BASE_URL') >= 0, 'QWENCLOUD_BASE_URL override is wired');
+  A.ok((profile.baseUrlEnv || []).indexOf('QWEN_BASE_URL') >= 0, 'QWEN_BASE_URL override is wired');
   A.eq(profile.priceFamily, 'qwen', 'qwen price family is wired');
   A.eq(prices.priceOf('qwen', 'qwen-plus').in, 0.40, 'qwen-plus has list pricing for spend caps');
 
@@ -21,7 +24,13 @@ module.exports = (async () => {
   };
   const p = factory.selectProvider({ provider: 'qwencloud', fetch: fetchImpl, key: 'dashscope-test-key' });
   const models = await p.listModels();
+  A.ok(calls.some(c => String(c.url).startsWith('https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models')), 'listModels hits the intl default base URL');
   A.eq(models[0].id, 'qwen-plus', 'lists models from DashScope /models');
+  const chinaBase = 'https://dashscope.aliyuncs.com/compatible-mode/v1';
+  calls.length = 0;
+  const regional = factory.selectProvider({ provider: 'qwencloud', fetch: fetchImpl, key: 'dashscope-test-key', baseUrl: chinaBase });
+  await regional.listModels();
+  A.ok(calls.some(c => String(c.url).startsWith(chinaBase + '/models')), 'explicit baseUrl override reaches the China host');
   A.eq(p.supportsTools('qwen-plus'), true, 'profile asserts tool support when catalog is silent');
   A.eq(p.supportsTools('brand-new-qwen-model'), true, 'unknown qwencloud ids inherit profile tool support');
   for await (const _ of p.stream({ model: 'qwen-plus', messages: [], reasoningEffort: 'medium' })) { /* drain */ }

--- a/test/provider.registry.test.js
+++ b/test/provider.registry.test.js
@@ -10,7 +10,7 @@ module.exports = (async () => {
   A.ok(ids.indexOf('openai') >= 0, 'openai is registered');
   A.ok(ids.indexOf('anthropic') >= 0, 'anthropic is registered');
   A.ok(ids.indexOf('gemini') >= 0, 'gemini is registered');
-  ['xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras'].forEach(id => {
+  ['xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras', 'qwencloud'].forEach(id => {
     A.ok(ids.indexOf(id) >= 0, id + ' is registered');
   });
   A.ok(ids.indexOf('grok') >= 0, 'grok (OAuth) is registered');
@@ -31,13 +31,15 @@ module.exports = (async () => {
   A.eq(factory.normalizeProviderId('together-ai', ''), 'together', 'Together alias normalizes');
   A.eq(factory.normalizeProviderId('fireworks-ai', ''), 'fireworks', 'Fireworks alias normalizes');
   A.eq(factory.normalizeProviderId('sonar', ''), 'perplexity', 'Perplexity alias normalizes');
+  A.eq(factory.normalizeProviderId('dashscope', ''), 'qwencloud', 'DashScope alias normalizes to qwencloud');
+  A.eq(factory.normalizeProviderId('qwen', ''), 'qwencloud', 'qwen alias normalizes to qwencloud');
   A.eq(factory.normalizeProviderId('', 'openrouter'), 'openrouter', 'fallback is honored');
   A.eq(factory.defaultReasoningEffortForProvider('codex'), 'low', 'codex default reasoning');
   A.eq(factory.defaultReasoningEffortForProvider('ollama'), 'none', 'ollama default reasoning');
   A.eq(factory.providerRequiresKey('openai'), true, 'openai requires a key');
   A.eq(factory.providerRequiresKey('anthropic'), true, 'anthropic requires a key');
   A.eq(factory.providerRequiresKey('gemini'), true, 'gemini requires a key');
-  ['xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras'].forEach(id => {
+  ['xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras', 'qwencloud'].forEach(id => {
     A.eq(factory.providerRequiresKey(id), true, id + ' requires a key');
   });
   A.eq(factory.providerRequiresKey('ollama'), false, 'ollama is keyless');
@@ -54,10 +56,17 @@ module.exports = (async () => {
   A.ok(together && together.baseUrl === 'https://api.together.ai/v1', 'Together profile uses its current official base URL');
   const perplexity = profiles.find(p => p.id === 'perplexity');
   A.ok(perplexity && perplexity.baseUrl === 'https://api.perplexity.ai', 'Perplexity profile uses Sonar base URL');
+  const qwencloud = profiles.find(p => p.id === 'qwencloud');
+  const rawQwencloud = factory.getProviderProfile('qwencloud');
+  A.ok(rawQwencloud && rawQwencloud.adapter === 'openai-compatible', 'QwenCloud uses the openai-compatible adapter');
+  A.ok(qwencloud && qwencloud.baseUrl === 'https://dashscope.aliyuncs.com/compatible-mode/v1', 'QwenCloud default base URL is DashScope compatible-mode');
+  A.ok(qwencloud && qwencloud.keyEnv.indexOf('DASHSCOPE_API_KEY') >= 0, 'QwenCloud reads DASHSCOPE_API_KEY first');
+  A.eq(rawQwencloud.priceFamily, 'qwen', 'QwenCloud declares the qwen price family');
+  A.eq(qwencloud.supportsTools, true, 'QwenCloud profile asserts tool support');
 
   const p = factory.selectProvider({ provider: 'ollama', fetch: async () => new Response(JSON.stringify({ data: [] }), { status: 200 }) });
   A.ok(p && typeof p.stream === 'function' && typeof p.listModels === 'function', 'factory returns an adapter for OpenAI-compatible profiles');
-  for (const id of ['xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras']) {
+  for (const id of ['xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras', 'qwencloud']) {
     const hosted = factory.selectProvider({ provider: id, fetch: async () => new Response(JSON.stringify({ data: [] }), { status: 200 }) });
     A.ok(hosted && typeof hosted.stream === 'function' && typeof hosted.listModels === 'function', 'factory returns OpenAI-compatible adapter for ' + id);
   }
@@ -71,6 +80,7 @@ module.exports = (async () => {
     A.eq(factory.getProviderProfile(id).wireReasoningEffort, true, id + ' documents the reasoning_effort wire param');
   });
   A.ok(!factory.getProviderProfile('custom').wireReasoningEffort, 'custom endpoints never assume reasoning_effort support');
+  A.ok(!factory.getProviderProfile('qwencloud').wireReasoningEffort, 'QwenCloud does not assume OpenAI reasoning_effort on the wire');
 
   // profile hints reach the adapter: Perplexity refuses tools up front and sends no stream_options
   {

--- a/test/provider.registry.test.js
+++ b/test/provider.registry.test.js
@@ -59,7 +59,7 @@ module.exports = (async () => {
   const qwencloud = profiles.find(p => p.id === 'qwencloud');
   const rawQwencloud = factory.getProviderProfile('qwencloud');
   A.ok(rawQwencloud && rawQwencloud.adapter === 'openai-compatible', 'QwenCloud uses the openai-compatible adapter');
-  A.ok(qwencloud && qwencloud.baseUrl === 'https://dashscope.aliyuncs.com/compatible-mode/v1', 'QwenCloud default base URL is DashScope compatible-mode');
+  A.ok(qwencloud && qwencloud.baseUrl === 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1', 'QwenCloud default base URL is the intl compatible-mode host');
   A.ok(qwencloud && qwencloud.keyEnv.indexOf('DASHSCOPE_API_KEY') >= 0, 'QwenCloud reads DASHSCOPE_API_KEY first');
   A.eq(rawQwencloud.priceFamily, 'qwen', 'QwenCloud declares the qwen price family');
   A.eq(qwencloud.supportsTools, true, 'QwenCloud profile asserts tool support');

--- a/test/sidecar.http.test.js
+++ b/test/sidecar.http.test.js
@@ -86,6 +86,15 @@ function boot(port, workspaces, attemptsLeft, extraEnv) {
         CEREBRAS_API_KEY: '',
         STARNET_CEREBRAS_API_KEY: '',
         SKYNET_CEREBRAS_API_KEY: '',
+        DASHSCOPE_API_KEY: '',
+        STARNET_DASHSCOPE_API_KEY: '',
+        SKYNET_DASHSCOPE_API_KEY: '',
+        QWENCLOUD_API_KEY: '',
+        STARNET_QWENCLOUD_API_KEY: '',
+        SKYNET_QWENCLOUD_API_KEY: '',
+        QWEN_API_KEY: '',
+        STARNET_QWEN_API_KEY: '',
+        SKYNET_QWEN_API_KEY: '',
         CUSTOM_OPENAI_BASE_URL: '',
         STARNET_CUSTOM_OPENAI_BASE_URL: '',
         SKYNET_CUSTOM_OPENAI_BASE_URL: '',
@@ -319,7 +328,7 @@ function boot(port, workspaces, attemptsLeft, extraEnv) {
     A.ok(providers.body.providers.some(p => p.id === 'openrouter'), 'providers include openrouter');
     A.ok(providers.body.providers.some(p => p.id === 'anthropic'), 'providers include anthropic');
     A.ok(providers.body.providers.some(p => p.id === 'gemini'), 'providers include gemini');
-    for (const id of ['xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras']) {
+    for (const id of ['xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras', 'qwencloud']) {
       A.ok(providers.body.providers.some(p => p.id === id), 'providers include ' + id);
     }
     A.ok(providers.body.providers.some(p => p.id === 'custom'), 'providers include custom OpenAI-compatible');
@@ -355,6 +364,26 @@ function boot(port, workspaces, attemptsLeft, extraEnv) {
       const goodCandidate = await j('POST', '/api/providers/validate', { provider: 'custom', baseUrl: liveBase, key: 'probe-good-key', model: 'local/proven-model' });
       A.eq(goodCandidate.body.credentialVerified, true, 'candidate-key validation proves the exact key on the inference wire');
     } finally { await new Promise(resolve => probeServer.close(resolve)); }
+
+    // Custom catalog: arbitrary model ids without capability metadata stay honestly unknown (null), not false.
+    const capServer = http.createServer((rq, rs) => {
+      rs.writeHead(200, { 'Content-Type': 'application/json' });
+      rs.end(JSON.stringify({ data: [
+        { id: 'arbitrary/custom-model', context_length: 8192 },
+        { id: 'tooly/model', context_length: 8192, supported_parameters: ['tools'] }
+      ] }));
+    });
+    await new Promise(resolve => capServer.listen(0, HOST, resolve));
+    try {
+      const capBase = 'http://' + HOST + ':' + capServer.address().port + '/v1';
+      const catalog = await j('GET', '/api/models/custom?baseUrl=' + encodeURIComponent(capBase));
+      A.eq(catalog.status, 200, 'GET /api/models/custom proxies an arbitrary OpenAI-compatible catalog');
+      const bare = catalog.body.models.find(m => m.id === 'arbitrary/custom-model');
+      const tooly = catalog.body.models.find(m => m.id === 'tooly/model');
+      A.ok(bare, 'arbitrary custom model ids are listed');
+      A.eq(bare.supportsTools, null, 'models without capability metadata serialize as unknown, not false');
+      A.eq(tooly.supportsTools, true, 'supported_parameters tools is positive proof of tool support');
+    } finally { await new Promise(resolve => capServer.close(resolve)); }
 
     const pushOpenAi = await fetch(B + '/api/key', {
       method: 'POST',

--- a/website/app/app/app.js
+++ b/website/app/app/app.js
@@ -790,7 +790,7 @@ const App = (() => {
     if (p === 'fireworks') return 'Fireworks API key';
     if (p === 'perplexity') return 'pplx-...  -  perplexity.ai/settings/api';
     if (p === 'cerebras') return 'Cerebras API key';
-    if (p === 'qwencloud') return 'sk-...  -  dashscope.console.aliyun.com/apiKey';
+    if (p === 'qwencloud') return 'sk-...  -  modelstudio.console.alibabacloud.com (China: dashscope.console.aliyun.com)';
     if (p === 'custom') return 'optional API key for this endpoint';
     return 'sk-or-...  -  openrouter.ai/keys';
   }
@@ -810,7 +810,7 @@ const App = (() => {
       fireworks: 'https://fireworks.ai/account/api-keys',
       perplexity: 'https://www.perplexity.ai/settings/api',
       cerebras: 'https://cloud.cerebras.ai',
-      qwencloud: 'https://dashscope.console.aliyun.com/apiKey',
+      qwencloud: 'https://modelstudio.console.alibabacloud.com/?tab=playground#/api-key',
       // not a key page: managed credits are obtained by LINKING a station in the STORE
       starnet: 'https://account.starnetos.com',
       openrouter: 'https://openrouter.ai/keys'

--- a/website/app/app/app.js
+++ b/website/app/app/app.js
@@ -733,6 +733,7 @@ const App = (() => {
       fireworks: 'FIREWORKS',
       perplexity: 'PERPLEXITY',
       cerebras: 'CEREBRAS',
+      qwencloud: 'QWENCLOUD',
       starnet: 'STARNET MANAGED',
       ollama: 'OLLAMA',
       custom: 'CUSTOM'
@@ -757,6 +758,7 @@ const App = (() => {
     if (p === 'fireworks' || p === 'fireworks-ai') return 'fireworks';
     if (p === 'perplexity' || p === 'pplx' || p === 'sonar') return 'perplexity';
     if (p === 'cerebras') return 'cerebras';
+    if (p === 'qwencloud' || p === 'qwen' || p === 'dashscope' || p === 'qwen-cloud' || p === 'alibaba') return 'qwencloud';
     // managed credits — its bearer is the linked device token, never a key the user pastes
     if (p === 'starnet' || p === 'starnet-cloud' || p === 'managed') return 'starnet';
     if (p === 'ollama' || p === 'ollama-local') return 'ollama';
@@ -788,6 +790,7 @@ const App = (() => {
     if (p === 'fireworks') return 'Fireworks API key';
     if (p === 'perplexity') return 'pplx-...  -  perplexity.ai/settings/api';
     if (p === 'cerebras') return 'Cerebras API key';
+    if (p === 'qwencloud') return 'sk-...  -  dashscope.console.aliyun.com/apiKey';
     if (p === 'custom') return 'optional API key for this endpoint';
     return 'sk-or-...  -  openrouter.ai/keys';
   }
@@ -807,6 +810,7 @@ const App = (() => {
       fireworks: 'https://fireworks.ai/account/api-keys',
       perplexity: 'https://www.perplexity.ai/settings/api',
       cerebras: 'https://cloud.cerebras.ai',
+      qwencloud: 'https://dashscope.console.aliyun.com/apiKey',
       // not a key page: managed credits are obtained by LINKING a station in the STORE
       starnet: 'https://account.starnetos.com',
       openrouter: 'https://openrouter.ai/keys'
@@ -817,8 +821,11 @@ const App = (() => {
   // stranding the user on an empty required field. Reuses the curated FALLBACK_MODELS lineup (first = best pick).
   function defaultModelFor(provider) {
     const p = normalizeProviderId(provider);
-    const list = FALLBACK_MODELS[p] || FALLBACK_MODELS.openrouter;
-    return (list && list[0]) || 'anthropic/claude-sonnet-4.6';
+    if (p === 'custom') return '';
+    const list = FALLBACK_MODELS[p];
+    if (list && list.length) return list[0];
+    if (p === 'openrouter') return (FALLBACK_MODELS.openrouter[0]) || 'anthropic/claude-sonnet-4.6';
+    return '';
   }
   function applyQuickModel(sel) {
     if (!agent || !sel) return;
@@ -1467,6 +1474,8 @@ const App = (() => {
     fireworks: ['accounts/fireworks/models/deepseek-v3p1', 'accounts/fireworks/models/kimi-k2p5', 'accounts/fireworks/models/llama-v3p3-70b-instruct'],
     perplexity: ['sonar-pro', 'sonar', 'sonar-reasoning-pro'],
     cerebras: ['llama-4-scout-17b-16e-instruct', 'llama3.1-8b', 'qwen-3-coder-480b'],
+    qwencloud: ['qwen-plus', 'qwen-max', 'qwen-turbo'],
+    custom: [],
     ollama: ['llama3.1', 'qwen2.5-coder', 'mistral'],
     openrouter: ['gpt-5.5', 'anthropic/claude-sonnet-4.6', 'anthropic/claude-opus-4.8', 'openai/gpt-5', 'google/gemini-2.5-pro']
   });
@@ -1497,12 +1506,14 @@ const App = (() => {
       // catalog unreachable (no network to openrouter.ai, or fetch blocked): seed the curated slugs MARKED
       // offline so the popover never reads as a verified live catalog. The screen stays usable — you can always
       // just type the slug you use.
-      const FALLBACK = FALLBACK_MODELS[p] || FALLBACK_MODELS.openrouter;
+      const FALLBACK = FALLBACK_MODELS[p] ?? (p === 'custom' ? [] : FALLBACK_MODELS.openrouter);
       genesisModels = FALLBACK.map(id => ({ id, name: id, fallback: true }));
       genesisOffline = true;
       countEl.textContent = '(catalog offline — type or pick a slug)';
-      if (!inp.value) inp.value = defId || FALLBACK[0];   // default-fill even offline so WAKE works; the Commander can overtype
-      inp.placeholder = 'type a model slug — e.g. ' + (defId || 'gpt-5.5');
+      if (!inp.value) inp.value = defId || FALLBACK[0] || '';
+      inp.placeholder = p === 'custom'
+        ? 'type a model slug for your endpoint'
+        : 'type a model slug — e.g. ' + (defId || FALLBACK[0] || 'gpt-5.5');
     }
     if (el('model-pop') && !el('model-pop').hidden) renderModelPop();   // live-refresh an open popover after a provider switch
     updateHint();
@@ -1564,6 +1575,10 @@ const App = (() => {
     cerebras: [
       { label: 'Llama 4 Scout', id: 'llama-4-scout-17b-16e-instruct', tag: 'fast' },
       { label: 'Llama 3.1 8B', id: 'llama3.1-8b', tag: '' }
+    ],
+    qwencloud: [
+      { label: 'Qwen Plus', id: 'qwen-plus', tag: 'balanced' },
+      { label: 'Qwen Max', id: 'qwen-max', tag: 'deepest' }
     ]
   });
   /* ---------- PHOSPHOR tint picker (the console-wide theme, surfaced at commission) ----------

--- a/website/app/app/harness.js
+++ b/website/app/app/harness.js
@@ -307,6 +307,7 @@ const Harness = (() => {
     if (p === 'fireworks' || p === 'fireworks-ai') return 'fireworks';
     if (p === 'perplexity' || p === 'pplx' || p === 'sonar') return 'perplexity';
     if (p === 'cerebras') return 'cerebras';
+    if (p === 'qwencloud' || p === 'qwen' || p === 'dashscope' || p === 'qwen-cloud' || p === 'alibaba') return 'qwencloud';
     // managed credits — bearer is the linked device token (mirrors app.js + registry.js aliases)
     if (p === 'starnet' || p === 'starnet-cloud' || p === 'managed') return 'starnet';
     if (p === 'ollama' || p === 'ollama-local') return 'ollama';
@@ -561,7 +562,7 @@ const Harness = (() => {
       name: (m && (m.name || m.id)) || '',
       pricing: (m && m.pricing) || null,
       context_length: (m && +m.context_length) || 0,
-      supportsTools: (m && typeof m.supportsTools === 'boolean') ? m.supportsTools : (params.length ? params.indexOf('tools') >= 0 : true),
+      supportsTools: (m && typeof m.supportsTools === 'boolean') ? m.supportsTools : (params.indexOf('tools') >= 0 ? true : null),
       supportsReasoning: !!(m && m.supportsReasoning),
       supported_parameters: params,
       reasoningEfforts: Array.isArray(m && m.reasoningEfforts) ? m.reasoningEfforts.slice() : []

--- a/website/app/app/modeldock.js
+++ b/website/app/app/modeldock.js
@@ -20,7 +20,8 @@ const ModelDock = (() => {
     together: ['meta-llama/Llama-3.3-70B-Instruct-Turbo', 'Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8', 'deepseek-ai/DeepSeek-V3'],
     fireworks: ['accounts/fireworks/models/deepseek-v3p1', 'accounts/fireworks/models/kimi-k2p5', 'accounts/fireworks/models/llama-v3p3-70b-instruct'],
     perplexity: ['sonar-pro', 'sonar', 'sonar-reasoning-pro'],
-    cerebras: ['llama-4-scout-17b-16e-instruct', 'llama3.1-8b', 'qwen-3-coder-480b']
+    cerebras: ['llama-4-scout-17b-16e-instruct', 'llama3.1-8b', 'qwen-3-coder-480b'],
+    qwencloud: ['qwen-plus', 'qwen-max', 'qwen-turbo']
   };
   // OpenRouter fallback seed — real slugs only (shown labelled "(catalog offline)" when the live fetch fails).
   const OPENROUTER_FALLBACK = [
@@ -57,7 +58,7 @@ const ModelDock = (() => {
     qwen: 'QWEN',
     cohere: 'COHERE'
   };
-  const PROVIDER_RANK = { starnet: -1, codex: 0, grok: 1, kimi: 2, openrouter: 3, openai: 4, anthropic: 5, gemini: 6, xai: 7, groq: 8, mistral: 9, deepseek: 10, together: 11, fireworks: 12, perplexity: 13, cerebras: 14, ollama: 15, custom: 16 };
+  const PROVIDER_RANK = { starnet: -1, codex: 0, grok: 1, kimi: 2, openrouter: 3, openai: 4, anthropic: 5, gemini: 6, xai: 7, groq: 8, mistral: 9, deepseek: 10, together: 11, fireworks: 12, perplexity: 13, cerebras: 14, qwencloud: 15, ollama: 16, custom: 17 };
 
   let opts = {};
   let wired = false;
@@ -72,7 +73,7 @@ const ModelDock = (() => {
   }
   function providerLabel(p) {
     p = normalizeProvider(p);
-    const map = { starnet: 'STARNET', codex: 'GPT / CODEX', grok: 'GROK OAUTH', kimi: 'KIMI OAUTH', openrouter: 'OPENROUTER', openai: 'OPENAI API', anthropic: 'ANTHROPIC', gemini: 'GEMINI', xai: 'XAI', groq: 'GROQ', mistral: 'MISTRAL', deepseek: 'DEEPSEEK', together: 'TOGETHER', fireworks: 'FIREWORKS', perplexity: 'PERPLEXITY', cerebras: 'CEREBRAS', ollama: 'OLLAMA', custom: 'CUSTOM' };
+    const map = { starnet: 'STARNET', codex: 'GPT / CODEX', grok: 'GROK OAUTH', kimi: 'KIMI OAUTH', openrouter: 'OPENROUTER', openai: 'OPENAI API', anthropic: 'ANTHROPIC', gemini: 'GEMINI', xai: 'XAI', groq: 'GROQ', mistral: 'MISTRAL', deepseek: 'DEEPSEEK', together: 'TOGETHER', fireworks: 'FIREWORKS', perplexity: 'PERPLEXITY', cerebras: 'CEREBRAS', qwencloud: 'QWENCLOUD', ollama: 'OLLAMA', custom: 'CUSTOM' };
     return map[p] || String(p || 'openrouter').toUpperCase();
   }
   function normalizeProvider(p) {
@@ -92,6 +93,7 @@ const ModelDock = (() => {
     if (p === 'fireworks' || p === 'fireworks-ai') return 'fireworks';
     if (p === 'perplexity' || p === 'pplx' || p === 'sonar') return 'perplexity';
     if (p === 'cerebras') return 'cerebras';
+    if (p === 'qwencloud' || p === 'qwen' || p === 'dashscope' || p === 'qwen-cloud' || p === 'alibaba') return 'qwencloud';
     // managed credits — bearer is the linked device token (mirrors app.js + registry.js aliases)
     if (p === 'starnet' || p === 'starnet-cloud' || p === 'managed') return 'starnet';
     if (p === 'ollama' || p === 'ollama-local') return 'ollama';
@@ -402,7 +404,7 @@ const ModelDock = (() => {
     renderList();
     // 'starnet' first: a linked station's own credits are the most direct way to run, and its catalog is
     // the whole managed lineup. providerEnabled() keeps it out of the list when no credits are configured.
-    const ids = ['starnet', 'codex', 'grok', 'kimi', 'openrouter', 'openai', 'anthropic', 'gemini', 'xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras', 'ollama', 'custom'];
+    const ids = ['starnet', 'codex', 'grok', 'kimi', 'openrouter', 'openai', 'anthropic', 'gemini', 'xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras', 'qwencloud', 'ollama', 'custom'];
     const active = provider();
     if (ids.indexOf(active) < 0) ids.unshift(active);
     const parts = await Promise.all(ids.map(p => fetchProviderModels(p, force)));
@@ -750,7 +752,7 @@ const ModelDock = (() => {
   // `ensure: { id, provider }` guarantees a specific model (e.g. an agent's own pin) is present even if the
   // provider is unconfigured, so the picker can always show + preselect it. Returns [{ id, name, provider, … }].
   async function computeCatalog(force, ensure) {
-    const ids = ['codex', 'grok', 'kimi', 'openrouter', 'openai', 'anthropic', 'gemini', 'xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras', 'ollama', 'custom'];
+    const ids = ['codex', 'grok', 'kimi', 'openrouter', 'openai', 'anthropic', 'gemini', 'xai', 'groq', 'mistral', 'deepseek', 'together', 'fireworks', 'perplexity', 'cerebras', 'qwencloud', 'ollama', 'custom'];
     const active = provider();
     if (ids.indexOf(active) < 0) ids.unshift(active);
     const parts = await Promise.all(ids.map(p => fetchProviderModels(p, force).catch(() => [])));

--- a/website/app/app/stationui.js
+++ b/website/app/app/stationui.js
@@ -3846,7 +3846,7 @@ const StationUI = typeof document === 'undefined' ? {} : (() => {
     { id: 'fireworks',     name: 'FIREWORKS',         endpoint: 'api.fireworks.ai/inference/v1', blurb: 'Fireworks API', live: true },
     { id: 'perplexity',    name: 'PERPLEXITY',        endpoint: 'api.perplexity.ai',          blurb: 'Sonar API', live: true },
     { id: 'cerebras',      name: 'CEREBRAS',          endpoint: 'api.cerebras.ai/v1',         blurb: 'Cerebras API', live: true },
-    { id: 'qwencloud',     name: 'QWENCLOUD',         endpoint: 'dashscope.aliyuncs.com/compatible-mode/v1', blurb: 'Alibaba DashScope API', live: true },
+    { id: 'qwencloud',     name: 'QWENCLOUD',         endpoint: 'dashscope-intl.aliyuncs.com/compatible-mode/v1', blurb: 'Qwen Cloud / Model Studio API', live: true },
     { id: 'ollama',        name: 'OLLAMA',            endpoint: '127.0.0.1:11434/v1',         blurb: 'local models', live: true },
     { id: 'custom',        name: 'CUSTOM',            endpoint: 'any /v1 base URL',           blurb: 'bring your endpoint', live: true }
   ];

--- a/website/app/app/stationui.js
+++ b/website/app/app/stationui.js
@@ -3846,6 +3846,7 @@ const StationUI = typeof document === 'undefined' ? {} : (() => {
     { id: 'fireworks',     name: 'FIREWORKS',         endpoint: 'api.fireworks.ai/inference/v1', blurb: 'Fireworks API', live: true },
     { id: 'perplexity',    name: 'PERPLEXITY',        endpoint: 'api.perplexity.ai',          blurb: 'Sonar API', live: true },
     { id: 'cerebras',      name: 'CEREBRAS',          endpoint: 'api.cerebras.ai/v1',         blurb: 'Cerebras API', live: true },
+    { id: 'qwencloud',     name: 'QWENCLOUD',         endpoint: 'dashscope.aliyuncs.com/compatible-mode/v1', blurb: 'Alibaba DashScope API', live: true },
     { id: 'ollama',        name: 'OLLAMA',            endpoint: '127.0.0.1:11434/v1',         blurb: 'local models', live: true },
     { id: 'custom',        name: 'CUSTOM',            endpoint: 'any /v1 base URL',           blurb: 'bring your endpoint', live: true }
   ];

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -193,6 +193,7 @@
                 <button class="prov tail" data-prov="fireworks" aria-pressed="false">FIREWORKS</button>
                 <button class="prov tail" data-prov="perplexity" aria-pressed="false">PERPLEXITY</button>
                 <button class="prov tail" data-prov="cerebras" aria-pressed="false">CEREBRAS</button>
+                <button class="prov tail" data-prov="qwencloud" aria-pressed="false">QWENCLOUD</button>
                 <button class="prov tail" data-prov="custom" aria-pressed="false">CUSTOM</button>
                 <!-- label is COMPUTED by setProviderRowExpanded() from the live .prov.tail count — never hardcoded -->
                 <button type="button" id="prov-more" class="prov-more" aria-expanded="false">＋ MORE</button>

--- a/website/docs/providers.html
+++ b/website/docs/providers.html
@@ -57,10 +57,17 @@ use any model you allow.</p>
 <li><b>Account sign-in:</b> ChatGPT (Codex), Grok, and Kimi for Coding. These use the provider's
 sign-in flow instead of asking you to paste an API key.</li>
 <li><b>Direct API keys:</b> OpenRouter, OpenAI, Anthropic, Google Gemini, xAI, Groq, Mistral,
-DeepSeek, Together AI, Fireworks AI, Perplexity, Cerebras, and Qwen Cloud (Alibaba DashScope).</li>
+DeepSeek, Together AI, Fireworks AI, Perplexity, Cerebras, and Qwen Cloud (Alibaba Model Studio /
+DashScope).</li>
 <li><b>Local and custom:</b> Ollama on your machine, or any custom endpoint that speaks the
 OpenAI-compatible wire format.</li>
 </ul>
+<p><b>Qwen Cloud endpoint:</b> the default OpenAI-compatible base URL is
+<code>https://dashscope-intl.aliyuncs.com/compatible-mode/v1</code> (the international Qwen Cloud host).
+If your API key is from the China Model Studio console, set
+<code>DASHSCOPE_BASE_URL</code> (or <code>QWENCLOUD_BASE_URL</code> / <code>QWEN_BASE_URL</code>) to
+<code>https://dashscope.aliyuncs.com/compatible-mode/v1</code> before starting the sidecar, or paste
+that URL in the provider connect screen.</p>
 <div class="callout"><b>Release note:</b> these docs track current source. The stable installer linked
 from the site can lag while the next Windows and macOS builds pass signing and notarization.</div>
 

--- a/website/docs/providers.html
+++ b/website/docs/providers.html
@@ -57,7 +57,7 @@ use any model you allow.</p>
 <li><b>Account sign-in:</b> ChatGPT (Codex), Grok, and Kimi for Coding. These use the provider's
 sign-in flow instead of asking you to paste an API key.</li>
 <li><b>Direct API keys:</b> OpenRouter, OpenAI, Anthropic, Google Gemini, xAI, Groq, Mistral,
-DeepSeek, Together AI, Fireworks AI, Perplexity, and Cerebras.</li>
+DeepSeek, Together AI, Fireworks AI, Perplexity, Cerebras, and Qwen Cloud (Alibaba DashScope).</li>
 <li><b>Local and custom:</b> Ollama on your machine, or any custom endpoint that speaks the
 OpenAI-compatible wire format.</li>
 </ul>


### PR DESCRIPTION
## Summary
- Add a first-class `qwencloud` provider for Alibaba Cloud Model Studio / DashScope OpenAI-compatible Chat Completions.
- Add Qwen/DashScope aliases, key/base URL env support, Qwen pricing, UI/provider surfaces, Tauri credential wiring, and provider docs.
- Harden generic `custom` OpenAI-compatible behavior so arbitrary model slugs are not replaced with OpenRouter fallbacks and unknown tool capability remains `null` instead of being inferred as unsupported.

## Fork validation
- This branch was first reviewed and merged in the fork: https://github.com/Crunchy-Bytes-Team/starnet/pull/1
- Davide performed a local live-app smoke test before the fork merge and confirmed the QwenCloud flow worked correctly.

## Safety / contributing checks
- Branch diff is based on upstream `feat/harness-backend` (`d69931f4`).
- Scope is limited to provider registry/pricing/UI/docs/credentials/tests and the related custom-provider fallback/capability fix.
- No credentials or generated release artifacts committed.
- `gitleaks` was not installed in the local environment, so `npm run security:secrets` was not available under the CONTRIBUTING "if installed" condition.

## Verification
Targeted tests passed on this head before opening the upstream PR:

```bash
node test/provider.openai-compatible.test.js
# provider.openai-compatible.test: OK (50 assertions)

node test/provider.registry.test.js
# provider.registry.test: OK (109 assertions)

node test/prices.all-providers.test.js
# prices.all-providers.test: OK (125 assertions)

node test/provider-connections-ui.test.js
# provider-connections-ui.test.js OK - 59 assertions

node test/ctx-model-catalog.test.js
# ctx-model-catalog: OK (24 assertions)

node test/sidecar.http.test.js
# sidecar.http.test: OK (489 assertions)

node test/provider.qwencloud.test.js
# provider.qwencloud.test: OK (13 assertions)

node scripts/sync-website-app.mjs --check
# website-app-sync: OK — website/app matches frontend
```

Required broad gates were attempted:

```bash
npm run test:fast
# Fails at test/eval-fixture-host.test.js with SyntaxError: Cannot use import statement outside a module

npm run test:http
# Fails at test/output-recovery.e2e.test.js with 4 existing output-recovery assertions
```

Both broad-gate failures were reproduced on the unmodified base `refs/remotes/fork/feat-harness-backend` / upstream `feat/harness-backend` in a temporary worktree, so they are not introduced by this PR.
