### PR TITLE
feat(recruitment): randomize crew avatars

### DIFF
--- a/frontend/app/app.js
+++ b/frontend/app/app.js
@@ -1196,6 +1196,7 @@ const App = (() => {
       currentSpecialtyId: agent.specialtyId || null,
       nextAgentName: className => AgentId.allocName(className, liveAgents()),
       nameConflict: name => AgentId.nameConflict(name, liveAgents()),
+      usedSkins: () => liveAgents().map(a => a && a.skin).filter(Boolean),
       displayNameLimit: AgentId.NAME_MAX
     });
     // surface the REAL concurrency ceiling in the bay so "summon as many as you like" doesn't imply they all

--- a/frontend/app/avatar-randomizer.js
+++ b/frontend/app/avatar-randomizer.js
@@ -1,0 +1,27 @@
+/* STARNET — avatar-randomizer.js : pick a recruitment avatar, preferring skins the crew is not using.
+
+   Pure + node-testable. The Recruitment Bay supplies the valid skin ids, the live roster's skin ids,
+   and Math.random. Keeping roster lookup outside this helper means it never invents station state. */
+'use strict';
+(function (root, factory) {
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  else root.AvatarRandomizer = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
+
+  function pick(skinIds, usedSkinIds, random) {
+    const valid = Array.from(new Set((Array.isArray(skinIds) ? skinIds : []).filter(Boolean)));
+    if (!valid.length) return null;
+
+    const used = new Set((Array.isArray(usedSkinIds) ? usedSkinIds : []).filter(Boolean));
+    const unused = valid.filter(id => !used.has(id));
+    const pool = unused.length ? unused : valid;
+    const rng = typeof random === 'function' ? random : Math.random;
+    const roll = Number(rng());
+    const bounded = Number.isFinite(roll) ? Math.max(0, Math.min(0.9999999999999999, roll)) : 0;
+    return pool[Math.floor(bounded * pool.length)];
+  }
+
+  return { pick };
+});

--- a/frontend/app/marketplace.js
+++ b/frontend/app/marketplace.js
@@ -806,7 +806,8 @@ const Marketplace = (() => {
         '<div class="mkt-skin-stage-frame"><img id="mkt-skin-stage-img" alt="" draggable="false"></div>' +
         '<figcaption class="mkt-skin-stage-name"><span class="mkt-stage-lbl">LIVE PREVIEW —</span> <span id="mkt-skin-stage-name"></span></figcaption>' +
       '</figure>';
-    return '<div class="mkt-skinbar"><label class="mkt-skinlabel">APPEARANCE <span class="mkt-hint">— the character this agent wears (your call, any class)</span></label>' +
+    return '<div class="mkt-skinbar"><div class="mkt-skin-head"><span class="mkt-skinlabel">APPEARANCE <span class="mkt-hint">— the character this agent wears (your call, any class)</span></span>' +
+      '<button type="button" class="bb sm mkt-randomize-skin" aria-label="Randomize appearance, preferring characters not already in the crew" title="prefer a character not already in the crew">⤨ RANDOMIZE</button></div>' +
       '<div class="mkt-skin-section">' +
         '<div class="skin-picker" id="mkt-skin-picker">' + thumbs + '</div>' +
         stage +
@@ -2096,26 +2097,24 @@ const Marketplace = (() => {
      that would tear the focused input out from under the Commander mid-word. Every name-driven surface is
      therefore patched in place (counter, helper, aria-invalid, and every .mkt-candidate-name echo including the
      CTA's). Called from wireDossier so it re-binds on both a full stage render and a dossier-only repaint. */
-  function wireSummonConfig(sc) {
-    const nameIn = sc.querySelector('#mkt-summon-name');
-    if (nameIn) nameIn.addEventListener('input', () => {
-      pickedSummonName = nameIn.value;
-      const s = (focusAgent && Specialties.get(focusAgent)) || null;
-      root.querySelectorAll('.mkt-candidate-name').forEach(e => { e.textContent = summonCandidateName(s); });
-      const used = ((typeof AgentId !== 'undefined' && AgentId.normalizeName) ? AgentId.normalizeName(pickedSummonName) : String(pickedSummonName || '')).length;
-      const max = (ctx && ctx.displayNameLimit) || (typeof AgentId !== 'undefined' && AgentId.NAME_MAX) || 18;
-      const count = root.querySelector('.mkt-name-count'); if (count) { count.textContent = used + ' / ' + max; count.classList.toggle('over', used > max); }
-      const issue = summonNameIssue(), dup = summonNameConflict();
-      const help = root.querySelector('.mkt-name-help');
-      if (help) {
-        help.textContent = issue === 'too-long' ? 'too long — shorten this name before summoning'
-          : dup ? 'duplicate name — summon requires a second confirmation; the agent id will remain unique'
-          : 'blank uses the proposed default: ' + summonCandidateName(s);
-        help.classList.toggle('warn', !!(issue || dup));
-      }
-      nameIn.setAttribute('aria-invalid', issue ? 'true' : 'false');
+  function wireRandomizeSkin(sc, skinWrap, showSkin) {
+    const randomize = sc.querySelector('.mkt-randomize-skin');
+    if (!randomize) return;
+    randomize.addEventListener('click', () => {
+      const ids = (typeof DATA !== 'undefined' && DATA.SKINS) ? Object.keys(DATA.SKINS) : [];
+      const used = (ctx && typeof ctx.usedSkins === 'function') ? ctx.usedSkins() : [];
+      const next = (typeof AvatarRandomizer !== 'undefined' && AvatarRandomizer.pick)
+        ? AvatarRandomizer.pick(ids, used, Math.random) : null;
+      if (!next) return;
+      pickedSummonSkin = next;
+      skinWrap.querySelectorAll('.skin-thumb').forEach(x => x.classList.toggle('sel', x.dataset.skin === next));
+      showSkin(next);
+      const chosen = skinWrap.querySelector('.skin-thumb[data-skin="' + next + '"]');
+      if (chosen && chosen.scrollIntoView) chosen.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+      sfx('click');
     });
-
+  }
+  function wireSummonConfig(sc) {
     const skinWrap = sc.querySelector('#mkt-skin-picker');
     if (skinWrap) {
       // stage handle (assigned by the mount below): drive THIS stage, not the module-level shortcut — the
@@ -2136,6 +2135,7 @@ const Marketplace = (() => {
       const stageImg = sc.querySelector('#mkt-skin-stage-img');
       const stageName = sc.querySelector('#mkt-skin-stage-name');
       if (stageImg && typeof SkinStage !== 'undefined') skinStage = SkinStage.mount(stageImg, stageName, pickedSummonSkin);
+      wireRandomizeSkin(sc, skinWrap, skin => { if (skinStage) skinStage.show(skin); });
     }
 
     // SUMMON model picker: fill the catalog async, then track the choice ('' model → inherit the orchestrator's).
@@ -2156,6 +2156,27 @@ const Marketplace = (() => {
         if (help) help.innerHTML = modelHelpHTML((focusAgent && Specialties.get(focusAgent)) || null);
       });
     }
+
+    // Wire the name last so the model-picker seam stays compact and easy to source-lock. Typing still patches
+    // only existing nodes — it never repaints the dossier or tears out the focused input.
+    const nameIn = sc.querySelector('#mkt-summon-name');
+    if (nameIn) nameIn.addEventListener('input', () => {
+      pickedSummonName = nameIn.value;
+      const s = (focusAgent && Specialties.get(focusAgent)) || null;
+      root.querySelectorAll('.mkt-candidate-name').forEach(e => { e.textContent = summonCandidateName(s); });
+      const used = ((typeof AgentId !== 'undefined' && AgentId.normalizeName) ? AgentId.normalizeName(pickedSummonName) : String(pickedSummonName || '')).length;
+      const max = (ctx && ctx.displayNameLimit) || (typeof AgentId !== 'undefined' && AgentId.NAME_MAX) || 18;
+      const count = root.querySelector('.mkt-name-count'); if (count) { count.textContent = used + ' / ' + max; count.classList.toggle('over', used > max); }
+      const issue = summonNameIssue(), dup = summonNameConflict();
+      const help = root.querySelector('.mkt-name-help');
+      if (help) {
+        help.textContent = issue === 'too-long' ? 'too long — shorten this name before summoning'
+          : dup ? 'duplicate name — summon requires a second confirmation; the agent id will remain unique'
+          : 'blank uses the proposed default: ' + summonCandidateName(s);
+        help.classList.toggle('warn', !!(issue || dup));
+      }
+      nameIn.setAttribute('aria-invalid', issue ? 'true' : 'false');
+    });
   }
 
   function wireDossier(scope) {

--- a/frontend/css/marketplace.css
+++ b/frontend/css/marketplace.css
@@ -724,6 +724,9 @@ button.mkt-archive-head:focus-visible { outline: 2px solid var(--gold); outline-
   box-shadow: var(--raise); }
 .mkt-skinlabel { display: block; color: var(--ph); letter-spacing: 1px; font-size: 13px; margin-bottom: 8px;
   text-shadow: 0 1px 0 #000, 0 0 8px var(--ph-glow2); }
+.mkt-skin-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 8px; }
+.mkt-skin-head .mkt-skinlabel { margin-bottom: 0; }
+.mkt-randomize-skin { flex: 0 0 auto; }
 /* two columns: a scrolling well of large thumbs on the left, the live stage pinned right */
 .mkt-skin-section { display: flex; gap: 13px; align-items: stretch; }
 .mkt-skin-section .skin-picker { flex: 1 1 auto; min-width: 0; display: grid;
@@ -789,6 +792,7 @@ button.mkt-archive-head:focus-visible { outline: 2px solid var(--gold); outline-
   border-bottom: 1px solid var(--ph-faint); }
 .mkt-config .mkt-skinbar:last-child { border-bottom: 0; }
 .mkt-config .mkt-skinlabel { margin-bottom: 10px; }
+.mkt-config .mkt-skin-head .mkt-skinlabel { margin-bottom: 0; }
 /* the helper line under a field: what the current setting actually resolves to (see modelHelpHTML) */
 .mkt-field-help { color: var(--ph-dim); font-size: 11.5px; line-height: 1.5; letter-spacing: .3px; margin-top: 8px; max-width: 62ch; }
 .mkt-field-help b { color: var(--ph-bright); font-weight: normal; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -714,6 +714,7 @@
 <script src="app/propanchor.js"></script>
 <script src="app/waitanchor.js"></script><!-- pure permission-blocked wait-anchor ladder (G4: world.js walks a blocked agent here) -->
 <script src="app/data-shim.js"></script>
+<script src="app/avatar-randomizer.js"></script><!-- Recruitment Bay randomizer: unused crew skins first, full catalog fallback -->
 <script src="app/skinstage.js"></script>
 <script src="js/sprite-load-plan.js"></script>
 <script src="js/assets.js"></script>

--- a/test/avatar-randomizer.test.js
+++ b/test/avatar-randomizer.test.js
@@ -1,0 +1,37 @@
+/* node test/avatar-randomizer.test.js — Recruitment Bay avatar randomization behavior + wiring. */
+'use strict';
+const A = require('./_assert.js');
+const fs = require('fs'); const path = require('path');
+const AvatarRandomizer = require('../frontend/app/avatar-randomizer.js');
+const read = f => fs.readFileSync(path.join(__dirname, '..', f), 'utf8');
+const app = read('frontend/app/app.js');
+const mkt = read('frontend/app/marketplace.js');
+const html = read('frontend/index.html');
+
+A.eq(AvatarRandomizer.pick(['bear', 'robot', 'alien'], ['bear'], () => 0), 'robot',
+  'randomization chooses from unused skins when at least one is available');
+A.eq(AvatarRandomizer.pick(['bear', 'robot', 'alien'], ['bear'], () => 0.999), 'alien',
+  'the complete unused pool is reachable');
+A.eq(AvatarRandomizer.pick(['bear', 'robot'], ['bear', 'robot'], () => 0), 'bear',
+  'when every skin is used, randomization falls back to the full valid catalog');
+A.eq(AvatarRandomizer.pick(['bear', 'robot'], ['bear', 'robot'], () => 0.999), 'robot',
+  'the complete fallback pool is reachable');
+A.eq(AvatarRandomizer.pick([], ['bear'], () => 0.5), null,
+  'an empty skin catalog fails closed without inventing an avatar');
+A.eq(AvatarRandomizer.pick(['bear', 'bear', 'robot'], [], () => 0.999), 'robot',
+  'duplicate catalog entries do not distort selection');
+A.eq(AvatarRandomizer.pick(['bear', 'robot'], [], () => NaN), 'bear',
+  'an invalid random value safely selects the first candidate');
+
+A.ok(html.indexOf('app/avatar-randomizer.js') < html.indexOf('app/marketplace.js'),
+  'the pure randomizer loads before the Recruitment Bay');
+A.ok(/usedSkins:\s*\(\)\s*=>\s*liveAgents\(\)\.map/.test(app),
+  'the Recruitment Bay receives used skins from the live crew registry');
+A.ok(/class="bb sm mkt-randomize-skin"/.test(mkt),
+  'the Appearance panel renders a randomize button');
+A.ok(/AvatarRandomizer\.pick\(ids, used, Math\.random\)/.test(mkt),
+  'the button delegates selection to the tested unused-first helper');
+A.ok(/pickedSummonSkin\s*=\s*next/.test(mkt) && /showSkin\(next\)/.test(mkt),
+  'randomization updates both the summon payload state and live preview');
+
+A.report('avatar-randomizer.test');

--- a/test/fast.list
+++ b/test/fast.list
@@ -512,6 +512,7 @@ test/prepare-node.test.js
 test/summon.id.test.js
 test/summon-desk-prompt.test.js
 test/recruit-identity-ui.test.js
+test/avatar-randomizer.test.js
 test/subagents.test.js
 test/orchestration.test.js
 test/domain-terminal.test.js


### PR DESCRIPTION
## What changed

<!-- Describe the problem and the focused change. -->

## Verification

- [ ] `npm run test:fast`
- [ ] Relevant HTTP/E2E or live-app verification completed## What changed
- Add a **Randomize** control to the recruitment appearance panel.
- Prefer avatar skins not already used by the current crew.
- Fall back to the complete avatar catalog when every skin is represented.
- Keep the selected tile, live preview, and summon payload synchronized.
- Include an accessible label and tooltip.

## Verification
- [x] `node test/avatar-randomizer.test.js` — 12 assertions pas## What changed
- Add a **Randomize** control to the recruitment appearance panel.
- Prefer avatar skins not already used by the current crew.
- Fall back to the complete avatar catalog when every skin is represented.
- Keep the selected tile, live preview, and summon payload synchronized.
- Include an accessible label and tooltip.
## What changed

- Add a **Randomize** control to the recruitment appearance panel.
- Prefer avatar skins not already used by the current crew.
- Fall back to the complete avatar catalog when every skin is represented.
- Keep the selected tile, live preview, and summon payload synchronized.
- Include an accessible label and tooltip.

## Verification

- [x] `node test/avatar-randomizer.test.js` — 12 assertions passed
- [x] `agent-model-select.test.js` — 65 assertions passed
- [x] `recruit-identity-ui.test.js` — 13 assertions passed
- [x] `avatar-randomizer.test.js` — 12 assertions passed
- [x] `git diff --check`
- [ ] `npm run test:fast` — reaches an unrelated existing failure in `ledger-reconcile.test.js`
- [ ] Relevant HTTP/E2E or live-app verification completed
- [x] No credentials, local workspaces, QA captures, or generated release artifacts committed

## Safety and truthfulness

No permission, data migration, or telemetry changes.
## Verification
- [x] `node test/avatar-randomizer.test.js` — 12 assertions passed
- [x] Adjacent recruitment tests passed (90 assertions total)
- [x] `git diff --check`

## Note
The full `npm run test:fast` currently reaches an unrelated existing failure in `ledger-reconcile.test.js`; the feature and adjacent recruitment tests are green.sed
- [x] `agent-model-select.test.js` — 65 assertions passed
- [x] `recruit-identity-ui.test.js` — 13 assertions passed
- [x] `avatar-randomizer.test.js` — 12 assertions passed
- [x] `git diff --check`

## Note
The full `npm run test:fast` currently reaches an unrelated existing failure in `ledger-reconcile.test.js`; the feature and adjacent recruitment tests are green.
- [ ] No credentials, local workspaces, QA captures, or generated release artifacts committed

## Safety and truthfulness

<!-- Note permission, data, migration, or telemetry implications. Write "none" when not applicable. -->
